### PR TITLE
Built REST API for DELETE operation

### DIFF
--- a/api/controllers/queries.js
+++ b/api/controllers/queries.js
@@ -173,11 +173,11 @@ const editArticle = (req, res, next) => {
 // SQL query for DELETE /articles/<:articleId>
 const deleteArticle = (req, res, next) => {
   db.none({
-    text: "DELETE FROM article WHERE articleId = $id",
+    text: "DELETE FROM article WHERE articleId = $1",
     values: [req.params.articleId]
   })
     .then(() => {
-      res.status(201).json({
+      res.status(200).json({
         status: "success",
         data: {
           message: "Article successfully deleted"

--- a/api/routes/teamwork.js
+++ b/api/routes/teamwork.js
@@ -43,14 +43,7 @@ router.post("/gifs/:gifid/comment", (req, res, next) => {
 router.patch("/articles/:articleid", routeAuth.auth, teamworkQuery.editArticle);
 
 // employees can delete their articles
-router.delete("/articles/:articleId", (req, res, next) => {
-  res.status(200).json({
-    status: "success",
-    data: {
-      message: "Article successfully deleted"
-    }
-  });
-});
+router.delete("/articles/:articleId", routeAuth.auth, teamworkQuery.deleteArticle);
 
 // employees can delete their gifs
 router.delete("/gifs/:gifId", (req, res, next) => {

--- a/test/teamwork.spec.js
+++ b/test/teamwork.spec.js
@@ -203,7 +203,7 @@ describe("Teamwork App", () => {
   });
 
   // employees can edit their article
-  describe("PATCH /articles/<:articleId>", () => {
+  describe("PATCH /articles/<articleId>", () => {
     let articleid;
     before(done => {
       db.one(
@@ -240,11 +240,22 @@ describe("Teamwork App", () => {
   });
 
   // employees can delete their articles
-  describe("DELETE /articles/<:articleId>", () => {
+  describe("DELETE /articles/<articleId>", () => {
+    let articleid;
+    before(done => {
+      db.one(
+        // Insert default Article into table article
+        "INSERT INTO article (title, article) VALUES ($1, $2) RETURNING articleid",
+        [usr.defaultArticle.title, usr.defaultArticle.article]
+      ).then(val => {
+        articleid = val.articleid;
+        done();
+      });
+    });
     it("returns json data and responds with status code 200", done => {
       request(app)
-        .delete("/api/v1/articles/:articleId")
-        .set("header", "application/json")
+        .delete(`/api/v1/articles/${articleid}`)
+        .set("authorization", userToken)
         .expect("Content-Type", /json/)
         .end((err, res) => {
           if (err) return done(err);
@@ -263,7 +274,7 @@ describe("Teamwork App", () => {
   });
 
   // employees can delete their gif
-  describe("DELETE /gifs/<:gifId>", () => {
+  describe("DELETE /gifs/<gifId>", () => {
     it("responds with status code 200 and returns json object", done => {
       request(app)
         .delete("/api/v1/gifs/:gifId")


### PR DESCRIPTION
_Have DELETE operation on Teamwork's REST API_

**Task to be completed**
DELETE /gifs/<gifid>
POST /articles/<articleid>/comment
POST /gifs/<gifid>/comment
GET /feed
GET /articles/<articleid>
GET /gifs/<gifid>

**How should this be manually tested**
After cloning the repo, cd into it and run `npm init` then `npm run test`

- Using Postman, test every endpoint with:
      For header:  _key:_ Content-Type    _value:_ application/json
      For params: Generate articleid from POST /articles endpoint; in Params tab - _key:_ articleid  _value:_ (id from POST /articles endpoint)
      For authentication: Generate token from POST /auth/signin endpoint; in Authorization tab select:
         _Type:_ Bearer Token     _Token:_JWT TOKEN